### PR TITLE
update nct schema blender

### DIFF
--- a/schemas/stream/blender/flight.schema.json
+++ b/schemas/stream/blender/flight.schema.json
@@ -66,7 +66,9 @@
             "required": ["message", "synced", "projected"]
         },
         "nct": {
-            "$ref": "./nct.schema.json"
+            "title": "Non conflicting traffic",
+            "type": "array",
+            "items": { "$ref": "./nct.schema.json" }
         },
         "pcds": {
             "title": "Potential conflicts detected",

--- a/schemas/stream/blender/flight.schema.json
+++ b/schemas/stream/blender/flight.schema.json
@@ -65,7 +65,7 @@
             "additionalProperties": false,
             "required": ["message", "synced", "projected"]
         },
-        "nct": {
+        "ncts": {
             "title": "Non conflicting traffic",
             "type": "array",
             "items": { "$ref": "./nct.schema.json" }

--- a/schemas/stream/blender/nct.schema.json
+++ b/schemas/stream/blender/nct.schema.json
@@ -39,5 +39,5 @@
         }
     },
     "additionalProperties": false,
-    "required": ["id", "flightId", "sectorId", "isNct", "mode", "showHalo", "epoch", "projExit"]
+    "required": ["id", "flightId", "isNct", "epoch", "mode", "showHalo"]
 }

--- a/schemas/stream/blender/pcd.schema.json
+++ b/schemas/stream/blender/pcd.schema.json
@@ -26,7 +26,7 @@
             "type": "boolean"
         },
         "mode": {
-            "type": "Calculation mode",
+            "title": "Calculation mode",
             "enum": ["enhanced", "horizontal"]
         },
         "epoch": {


### PR DESCRIPTION
Updates blender schema with `ncts` as array. Previously there was nct single element with varying caculation mode (acg vs soft) depending on geographical coordinates.

`ncts` can be empty in case there is no nct active or current deactivation by pcd.
