### PR TITLE
update blender schema - message distributed by flights

### DIFF
--- a/schemas/stream/blender/blender.schema.json
+++ b/schemas/stream/blender/blender.schema.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/databeacon/level5-schemas/main/schemas/stream/blender/blender.schema.json",
+    "title": "Blender",
+    "version": "1.0.1",
+    "description": "Asynchronous topics merging.",
+    "type": "object",
+    "properties": {
+        "epoch": {
+            "title": "Synched time, POSIX in seconds.",
+            "type": "integer"
+        },
+        "num_hexcells": {
+            "title": "Number of hexcells expected.",
+            "type": "integer"
+        },
+        "expected_hexcells": {
+            "title": "List of expected hexcells.",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "hexcell_id": {
+            "title": "Message hexcell. Flights included have sync position in the hexcell.",
+            "type": "string"
+        },
+        "flights": {
+            "type": "array",
+            "title": "Flights data",
+            "items": { "$ref": "./flight.schema.json" }
+        }
+    },
+    "additionalProperties": false,
+    "required": ["epoch", "num_hexcells", "expected_hexcells", "hexcell_id", "flights"]
+}

--- a/schemas/stream/blender/blender.schema.json
+++ b/schemas/stream/blender/blender.schema.json
@@ -10,18 +10,18 @@
             "title": "Synched time, POSIX in seconds.",
             "type": "integer"
         },
-        "num_hexcells": {
+        "hexcellsNumber": {
             "title": "Number of hexcells expected.",
             "type": "integer"
         },
-        "expected_hexcells": {
+        "hexcellsExpected": {
             "title": "List of expected hexcells.",
             "type": "array",
             "items": {
                 "type": "string"
             }
         },
-        "hexcell_id": {
+        "hexcellId": {
             "title": "Message hexcell id. Flights included have sync position within hexcell boundaries.",
             "type": "string"
         },
@@ -32,5 +32,10 @@
         }
     },
     "additionalProperties": false,
-    "required": ["epoch", "num_hexcells", "expected_hexcells", "hexcell_id", "flights"]
+    "required": [
+        "epoch",
+        "hexcellsNumber",
+        "hexcellsExpected",
+        "hexcellId",
+        "flights"]
 }

--- a/schemas/stream/blender/blender.schema.json
+++ b/schemas/stream/blender/blender.schema.json
@@ -22,7 +22,7 @@
             }
         },
         "hexcell_id": {
-            "title": "Message hexcell. Flights included have sync position in the hexcell.",
+            "title": "Message hexcell id. Flights included have sync position within hexcell boundaries.",
             "type": "string"
         },
         "flights": {

--- a/schemas/stream/blender/flight.schema.json
+++ b/schemas/stream/blender/flight.schema.json
@@ -9,10 +9,6 @@
             "description": "Flight unique identifier",
             "type": "string"
         },
-        "active": {
-            "description": "Flag for active flight (false refers to timeout))",
-            "type": "boolean"
-        },
         "gs": {
             "description": "Aircraft groundspeed in kts",
             "type": "number"


### PR DESCRIPTION
Blender PR: https://github.com/databeacon/mike5-blender/pull/82

Main changes:
- Blender split by hexcell
- Root includes:
    - `epoch: integer`
    - `num_hexcells: integer`
    - `expected hexcells: array<string>`
    - `hexcell_id: string`
    - `flights: array<flights>`

Currently resolution set to 1, which corresponds to 22 hexcells in Europe (res 2 would be ~165)

Bref: single big message (array of flights in Europe) -> many smaller messages (array of flight by hexcell)