### PR TITLE
blender - add horizontalStatus and selectedHeading

### DIFF
--- a/schemas/stream/blender/flight.schema.json
+++ b/schemas/stream/blender/flight.schema.json
@@ -37,6 +37,10 @@
             "description": "Categorical vertical status",
             "enum": ["climbing", "descending", "cruising", "unknown"]
         },
+        "horizontalStatus": {
+            "description": "Categorical horizontal status",
+            "enum": ["right-turn", "left-turn", "cruising", "unknown"]
+        },
         "callsign": {
             "description": "Callsign identifying the flight. Typically, ICAO airline code plus IATA/ticketing flight number, or the aircraft registration",
             "type": "string"

--- a/schemas/stream/blender/flight.schema.json
+++ b/schemas/stream/blender/flight.schema.json
@@ -29,6 +29,10 @@
             "description": "Mode-S selected flight level, eg. FLXXX",
             "type": "integer"
         },
+        "selectedHeading": {
+            "description": "Mode-S selected heading in degrees",
+            "type": "integer"
+        },
         "verticalSpeed": {
             "description": "Vertical speed as feet per minute",
             "type": "integer"
@@ -101,6 +105,7 @@
         "selectedFlightLevel",
         "verticalSpeed",
         "verticalStatus",
+        "horizontalStatus",
         "callsign",
         "aprtDeparture",
         "aprtArrival",


### PR DESCRIPTION
Adds horizontalStatus and selectedHeading to blender flight schema:

```
 "horizontalStatus": {
     "description": "Categorical horizontal status",
     "enum": ["right-turn", "left-turn", "cruising", "unknown"]
}
````
```
"selectedHeading": {
     "description": "Mode-S selected heading in degrees",
     "type": "integer"
 }
```