### PR TITLE
update flight and nct blender schema

### DIFF
--- a/schemas/stream/blender/flight.schema.json
+++ b/schemas/stream/blender/flight.schema.json
@@ -74,7 +74,7 @@
             "type": "string"
         },
         "cumFuel": {
-            "description": "Accumulated fuel in kg since flight entered controlled air volume (currently EU, AUS)",
+            "description": "Accumulated fuel in kg since flight entered controlled air volume e.g. 'EU', 'AUS'",
             "type": "number"
         },
         "badaAttitude": {

--- a/schemas/stream/blender/flight.schema.json
+++ b/schemas/stream/blender/flight.schema.json
@@ -73,15 +73,15 @@
             "description": "Aircraft registration code",
             "type": "string"
         },
-        "cumFuel": {
+        "badaFuelAcc": {
             "description": "Accumulated fuel in kg since flight entered controlled air volume e.g. 'EU', 'AUS'",
             "type": "number"
         },
-        "badaAttitude": {
+        "attitude": {
             "description": "Categorical attiude for fuel estimation using BADA",
             "enum": ["CRUISE", "CLIMB", "DESCEND"]
         },
-        "badaVertSpeed": {
+        "computedVz": {
             "description": "Vertical speed retrieved from differentiation with previous point for debug purposes",
             "type": "number"
         },

--- a/schemas/stream/blender/flight.schema.json
+++ b/schemas/stream/blender/flight.schema.json
@@ -57,13 +57,33 @@
             "description": "Wind direction in degrees from Flight Aware data source (opposite direction to wind vector)",
             "type": "number"
         },
-        "aprtDeparture": {
+        "aprtDep": {
             "description": "Departure airport. ICAO format",
             "type": "string"
         },
-        "aprtArrival": {
+        "aprtArr": {
             "description": "Arrival airport. ICAO format",
             "type": "string"
+        },
+        "acType": {
+            "description": "Aircraft type",
+            "type": "string"
+        },
+        "acReg": {
+            "description": "Aircraft registration code",
+            "type": "string"
+        },
+        "cumFuel": {
+            "description": "Accumulated fuel in kg since flight entered controlled air volume (currently EU, AUS)",
+            "type": "number"
+        },
+        "badaAttitude": {
+            "description": "Categorical attiude for fuel estimation using BADA",
+            "enum": ["CRUISE", "CLIMB", "DESCEND"]
+        },
+        "badaVertSpeed": {
+            "description": "Vertical speed retrieved from differentiation with previous point for debug purposes",
+            "type": "number"
         },
         "points4d": {
             "title": "Flight positions",

--- a/schemas/stream/blender/nct.schema.json
+++ b/schemas/stream/blender/nct.schema.json
@@ -14,7 +14,7 @@
             "type": "string"
         },
         "sectorId": {
-            "description": "Sector unique identifier",
+            "description": "Sector unique identifier. Available when acg mode",
             "type": "string"
         },
         "isNct": {
@@ -34,7 +34,7 @@
             "type": "integer"
         },
         "projExit": {
-            "description": "Last projected position estimated to be non-conflicting.",
+            "description": "Last projected position estimated to be non-conflicting. Available when isNct true.",
             "$ref": "./point4d.schema.json"
         }
     },

--- a/schemas/stream/blender/nct.schema.json
+++ b/schemas/stream/blender/nct.schema.json
@@ -34,7 +34,7 @@
             "type": "integer"
         },
         "projExit": {
-            "description": "Last projected position estimated to be non-conflicting. Available when isNct true.",
+            "description": "Position projection at non-conflicting end estimation (exit sector for acg, time end for soft) . Available when isNct true.",
             "$ref": "./point4d.schema.json"
         }
     },


### PR DESCRIPTION
Updates flight schema including:
- `acType`
- `acReg`
- `badaFuelAcc`
- `attitude`
- `computedVz`

Update description in blender nct sub-schema. Note that:
- Single schema but some fields are optional
- `ProjExit` would refer to end of non-conflicting estimation in case of soft-nct
    Name to be reviewed
